### PR TITLE
Fixed invalid copy variable AllowHotkey in SiSCopyFromToEntity

### DIFF
--- a/src/sis_driver.c
+++ b/src/sis_driver.c
@@ -1443,7 +1443,7 @@ SiSCopyFromToEntity(ScrnInfoPtr pScrn)
 	  pSiS->useEXA = pSiSEnt->useEXA;
 	  pSiS->TurboQueue = pSiSEnt->TurboQueue;
 	  pSiS->restorebyset = pSiSEnt->restorebyset;
-	  pSiS->AllowHotkey = pSiS->AllowHotkey;
+	  pSiS->AllowHotkey = pSiSEnt->AllowHotkey;
 	  pSiS->OptROMUsage = pSiSEnt->OptROMUsage;
 	  pSiS->OptUseOEM = pSiSEnt->OptUseOEM;
 	  pSiS->forceCRT1 = pSiSEnt->forceCRT1;


### PR DESCRIPTION
@rasdark, it serious bug.