### PR TITLE
Align structures for 64-bit platforms

### DIFF
--- a/src/sis_vb.h
+++ b/src/sis_vb.h
@@ -128,9 +128,9 @@ static const SiS_LCD_StStruct SiS661_LCD_Type[]=
  */
 typedef struct _SiSTVVScale {
         UShort ScaleVDE;
-	int sindex;
 	UShort RealVDE;
 	UShort reg[4];
+    int sindex;
 } MySiSTVVScale, *MySiSTVVScalePtr;
 
 static const MySiSTVVScale SiSTVVScale[] = {

--- a/src/sis_video.h
+++ b/src/sis_video.h
@@ -408,6 +408,8 @@ static XF86ImageRec SISImages[NUM_IMAGES_330] =
 
 
 typedef struct {
+    DisplayModePtr  currentmode;
+
     int pixelFormat;
 
     CARD16  pitch;
@@ -435,8 +437,6 @@ typedef struct {
     CARD16  SCREENheight;
 
     CARD16  lineBufSize;
-
-    DisplayModePtr  currentmode;
 
 #ifdef SISMERGED
     CARD16  pitch2;
@@ -474,7 +474,7 @@ typedef struct {
 
     CARD16  oldLine, oldtop;
 
-    CARD8   (*VBlankActiveFunc)(SISPtr, SISPortPrivPtr);  
+    CARD8   (*VBlankActiveFunc)(SISPtr, SISPortPrivPtr);
 #if 0
     CARD32  (*GetScanLineFunc)(SISPtr pSiS);
 #endif

--- a/src/vstruct.h
+++ b/src/vstruct.h
@@ -109,8 +109,8 @@ struct SiS_CHTVRegData {
 };
 
 struct SiS_St {
+    unsigned short St_ModeFlag;
 	unsigned char  St_ModeID;
-	unsigned short St_ModeFlag;
 	unsigned char  St_StTableIndex;
 	unsigned char  St_CRT2CRTC;
 	unsigned char  St_ResInfo;
@@ -144,9 +144,9 @@ struct SiS_StandTable_S {
 };
 
 struct SiS_Ext {
+    unsigned short Ext_ModeFlag;
+    unsigned short Ext_VESAID;
 	unsigned char  Ext_ModeID;
-	unsigned short Ext_ModeFlag;
-	unsigned short Ext_VESAID;
 	unsigned char  Ext_RESINFO;
 	unsigned char  VB_ExtTVFlickerIndex;
 	unsigned char  VB_ExtTVEdgeIndex;
@@ -157,14 +157,14 @@ struct SiS_Ext {
 };
 
 struct SiS_Ext2 {
+    unsigned short XRes;
+    unsigned short YRes;
 	unsigned short Ext_InfoFlag;
 	unsigned char  Ext_CRT1CRTC;
 	unsigned char  Ext_CRTVCLK;
 	unsigned char  Ext_CRT2CRTC;
 	unsigned char  Ext_CRT2CRTC_NS;
 	unsigned char  ModeID;
-	unsigned short XRes;
-	unsigned short YRes;
 	unsigned char  Ext_PDC;
 	unsigned char  Ext_FakeCRT2CRTC;
 	unsigned char  Ext_FakeCRT2Clk;


### PR DESCRIPTION
@rasdark, alignment allows you to optimize size structures when copying and moving.
In most cases, it reduces count instructions per processor clock cycle.