### PR TITLE
Fixed const invalid detection CPU cache size

### DIFF
--- a/src/sis_memcpy.c
+++ b/src/sis_memcpy.c
@@ -40,7 +40,22 @@
 extern unsigned int SISAllocateFBMemory(ScrnInfoPtr pScrn, void **handle, int bytesize);
 extern void	    SISFreeFBMemory(ScrnInfoPtr pScrn, void **handle);
 
-#define CPUBUFFERSIZE 2048       /* Size of /proc/cpuinfo buffer */
+#if defined(_SC_LEVEL1_DCACHE_LINE)
+#define CPUBUFFERSIZE   sysconf(_SC_LEVEL1_DCACHE_LINESIZE) * 1024       /* Size of /proc/cpuinfo buffer */
+#else
+size_t get_cache_l1_size()
+{
+    FILE * p = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
+    unsigned int i = 0;
+    if (p) {
+        fscanf(p, "%d", &i);
+        fclose(p);
+    }
+    return i * 1024;
+}
+
+#define CPUBUFFERSIZE get_cache_l1_size()
+#endif
 #define BUFFERSIZE (576 * 1152)  /* Matches 720x576 YUV420 */
 
 /************************************************************************/


### PR DESCRIPTION
@rasdark, there is also a gross mistake in writing video driver, it needs to be fixed.
Very often CPU can be soldered instead Celeron D220 to another one in ASUS K50C, K50IN, etc.
The driver must take into detect real size L1 cache provided by Linux system.