### PR TITLE
Fixed in SiS 315+ incorrect set custom gamma RGB options

### DIFF
--- a/src/sis_opt.c
+++ b/src/sis_opt.c
@@ -2318,7 +2318,7 @@ SiSOptions(ScrnInfoPtr pScrn)
 		      pSiS->XvGamma = pSiS->XvGammaGiven = TRUE;
 		      pSiS->XvGammaRedDef = pSiS->XvGammaRed;
 		      pSiS->XvGammaGreenDef = pSiS->XvGammaGreen;
-		      pSiS->XvGammaBlue = pSiS->XvGammaBlue;
+		      pSiS->XvGammaBlueDef = pSiS->XvGammaBlue;
 		   }
 		}
 	     }


### PR DESCRIPTION
@rasdark,

Affected video chips:

- SiS 315+ includes all later chips (+XGI)