### PR TITLE
Fixed misprint in condition blocks with not used LCDheight

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -370,12 +370,12 @@ SiS_GetModeID(int VGAEngine, unsigned int VBFlags, int HDisplay, int VDisplay,
 		}
 		break;
 	case 400:
-		if((!(VBFlags & CRT1_LCDA)) || ((LCDwidth >= 800) && (LCDwidth >= 600))) {
+		if((!(VBFlags & CRT1_LCDA)) || ((LCDwidth >= 800) && (LCDheight >= 600))) {
 			if(VDisplay == 300) ModeIndex = ModeIndex_400x300[Depth];
 		}
 		break;
 	case 512:
-		if((!(VBFlags & CRT1_LCDA)) || ((LCDwidth >= 1024) && (LCDwidth >= 768))) {
+		if((!(VBFlags & CRT1_LCDA)) || ((LCDwidth >= 1024) && (LCDheight >= 768))) {
 			if(VDisplay == 384) ModeIndex = ModeIndex_512x384[Depth];
 		}
 		break;


### PR DESCRIPTION
@rasdark, following code below, there is indeed typo and forgot to compare height.

https://github.com/GermanAizek/xf86-video-sis671/src/init.c#L503-L513

https://github.com/GermanAizek/xf86-video-sis671/src/init.c#L533-L543
