### PR TITLE
Fixed missing break in switch VDisplay mode 1280x720

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -676,6 +676,7 @@ SiS_GetModeID_LCD(int VGAEngine, unsigned int VBFlags, int HDisplay, int VDispla
 	     switch(VDisplay) {
 	     case 720:
 		ModeIndex = ModeIndex_1280x720[Depth];
+        break;
 	     case 768:
 		if(VGAEngine == SIS_300_VGA) {
 		   ModeIndex = ModeIndex_300_1280x768[Depth];


### PR DESCRIPTION
@rasdark, without break, following case will be executed, ModeIndex will be selected with 1280x768.