### PR TITLE
Removed excess check exist ptr before free

### DIFF
--- a/src/sis6326_video.c
+++ b/src/sis6326_video.c
@@ -185,7 +185,6 @@ void SIS6326InitVideo(ScreenPtr pScreen)
     if(num_adaptors)
 	xf86XVScreenInit(pScreen, adaptors, num_adaptors);
 
-    if(newAdaptors)
 	free(newAdaptors);
 }
 

--- a/src/sis_driver.c
+++ b/src/sis_driver.c
@@ -594,8 +594,8 @@ xf86DrvMsg(0, X_INFO, "SISProbe - test2\n");
 
     }
 
-    if(usedChipsSiS) free(usedChipsSiS);
-    if(usedChipsXGI) free(usedChipsXGI);
+    free(usedChipsSiS);
+    free(usedChipsXGI);
 xf86DrvMsg(0, X_INFO, "SISProbe end\n");
     return foundScreen;
 }
@@ -658,16 +658,13 @@ SISFreeRec(ScrnInfoPtr pScrn)
 	   * and we need the BIOS image and SiS_Private for the first
 	   * head.
 	   */
-	  if(pSiSEnt->BIOS)
-	     free(pSiSEnt->BIOS);
+	  free(pSiSEnt->BIOS);
 	  pSiSEnt->BIOS = pSiS->BIOS = NULL;
 
-	  if(pSiSEnt->SiS_Pr)
-	     free(pSiSEnt->SiS_Pr);
+      free(pSiSEnt->SiS_Pr);
 	  pSiSEnt->SiS_Pr = pSiS->SiS_Pr = NULL;
 
-	  if(pSiSEnt->RenderAccelArray)
-	     free(pSiSEnt->RenderAccelArray);
+      free(pSiSEnt->RenderAccelArray);
 	  pSiSEnt->RenderAccelArray = pSiS->RenderAccelArray = NULL;
 
 	  pSiSEnt->pScrn_1 = NULL;
@@ -733,9 +730,7 @@ SISFreeRec(ScrnInfoPtr pScrn)
 	     pScrn->currentMode = pScrn->modes;
 	     do {
 	        DisplayModePtr p = pScrn->currentMode->next;
-	        if(pScrn->currentMode->Private)
 	 	   free(pScrn->currentMode->Private);
-	 	if(pScrn->currentMode->name)
 	 	   free(pScrn->currentMode->name);
 	        free(pScrn->currentMode);
 	        pScrn->currentMode = p;
@@ -5301,7 +5296,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	     } else {
 		SISErrorLog(pScrn, mergednocrt1, mergeddisstr);
 	     }
-	     if(pSiS->CRT2pScrn) free(pSiS->CRT2pScrn);
+	     free(pSiS->CRT2pScrn);
 	     pSiS->CRT2pScrn = NULL;
 	     pSiS->MergedFB = FALSE;
 	  }
@@ -5350,7 +5345,7 @@ SISPreInit(ScrnInfoPtr pScrn, int flags)
 	   } else {
 	      SISErrorLog(pScrn, mergednocrt2, mergeddisstr);
 	   }
-	   if(pSiS->CRT2pScrn) free(pSiS->CRT2pScrn);
+	   free(pSiS->CRT2pScrn);
 	   pSiS->CRT2pScrn = NULL;
 	   pSiS->MergedFB = FALSE;
 	}

--- a/src/sis_mergedfb.c
+++ b/src/sis_mergedfb.c
@@ -913,7 +913,7 @@ SiSMFBInitMergedFB(ScrnInfoPtr pScrn)
        } else {
 
 	  SISErrorLog(pScrn, "Failed to allocate memory for CRT2 monitor, MergedFB mode disabled.\n");
-	  if(pSiS->CRT2pScrn) free(pSiS->CRT2pScrn);
+	  free(pSiS->CRT2pScrn);
 	  pSiS->CRT2pScrn = NULL;
 	  pSiS->MergedFB = FALSE;
 

--- a/src/sis_video.c
+++ b/src/sis_video.c
@@ -378,9 +378,7 @@ SISInitVideo(ScreenPtr pScreen)
        xf86XVScreenInit(pScreen, adaptors, num_adaptors);
     }
 
-    if(newAdaptors) {
-       free(newAdaptors);
-    }
+    free(newAdaptors);
 
 #ifdef ENABLEXvMC
     SiSInitMC(pScreen);


### PR DESCRIPTION
@rasdark, you can safely delete checks before free, this became possible after C89, code is cleaner.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is, made available for further allocation. If ptr is a null pointer, no action occurs.
```